### PR TITLE
Expose chrome.runtime.sendMessage to tests

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -5,6 +5,7 @@ const definitions = [
   { cmdMethod: 'setExtensionStorage', helperMethod: 'setStorage', cmdName: 'set ext stor', cmdArgNames: ['type', 'obj', 'opts'], cmdMessage: (args => [args[0], args[1]]) },
   { cmdMethod: 'getExtensionStorage', helperMethod: 'getStorage', cmdName: 'get ext stor', cmdArgNames: ['type', 'keys', 'opts'], cmdMessage: (args => [args[0], args[1]]) },
   { cmdMethod: 'execExtensionCommand', helperMethod: 'execCommand', cmdName: 'exec ext cmd', cmdArgNames: ['property', 'method', 'args', 'opts'], cmdMessage: (args => [args[0], args[1]]) },
+  { cmdMethod: 'sendExtensionMessage', helperMethod: 'sendMessage', cmdName: 'send ext msg', cmdArgNames: ['message'], cmdMessage: (args => args[0]) },
 ];
 
 const findOptsArg = (args, maxLength) => args[maxLength];

--- a/helpers.js
+++ b/helpers.js
@@ -2,7 +2,7 @@ const nanoid = require('nanoid');
 
 const common = require('./lib/common');
 
-const { responseType, commandType } = common.constants;
+const { responseType, commandType, messageType } = common.constants;
 const log = common.logger({ prefix: 'Cypress ext helpers' });
 
 const targetWindow = window.top;
@@ -19,7 +19,11 @@ function listenForResponse(message, timeout) {
         if (message.debug) log(`Got ${message.property}.${message.method}() response`, data, 'in response to:', message);
         targetWindow.removeEventListener('message', windowListener);
         if (data.error) {
-          reject(data.error);
+          if(data.error instanceof Error) {
+            reject(data.error);
+          } else {
+            reject(new Error(data.error));
+          }
         } else {
           resolve(data.response);
         }

--- a/helpers.js
+++ b/helpers.js
@@ -58,6 +58,23 @@ function sendBrowserCommand({ alias, timeout, debug, returnType }, property, met
   return promise;
 }
 
+function sendBrowserMessage({ alias, timeout, debug, returnType }, content) {
+  const responseId = nanoid(); // Unique ID to identify response
+  const message = {
+    cypressExtType: messageType,
+    responseId,
+    alias,
+    debug,
+    returnType,
+    content,
+  };
+
+  const promise = listenForResponse(message, timeout);
+  if (debug) log(`Sending chrome.runtime.sendMessage() command`, message);
+  targetWindow.postMessage(message, '*');
+  return promise;
+}
+
 function assertPresent(type) { if (typeof type !== 'string') throw new Error('Need to specify extension storage type (local, sync or managed)'); }
 function assertArray(args) { if (typeof args !== 'undefined' && !Array.isArray(args)) throw new Error('execCommand arg should be passed as an array of args, even on single value'); }
 
@@ -86,6 +103,9 @@ module.exports = function createHelpers(userContext = {}) {
     execCommand(property, method, args, opts = {}) {
       assertArray(args);
       return sendBrowserCommand(merge(ctx, opts), property, method, args);
+    },
+    sendMessage(message, opts = {}) {
+      return sendBrowserMessage(merge(ctx, opts), message);
     },
   };
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,7 @@
 const constants = {
   responseType: 'BrowserCommandResponse',
   commandType: 'BrowserCommand',
+  messageType: 'BrowserMessage'
 };
 
 function logger({ prefix }) {

--- a/loader.js
+++ b/loader.js
@@ -152,14 +152,14 @@ function onBeforeBrowserLaunch(browser = {}, args) {
     ));
     if (toLoad.length > 0) {
       const dirList = toLoad.map(o => o.destDir).join(',');
-      const existingLoadArgIndex = args.findIndex(arg => (
+      const existingLoadArgIndex = args.args.findIndex(arg => (
         (typeof arg === 'string') && arg.startsWith('--load-extension=')
       ));
       if (existingLoadArgIndex >= 0) {
         // eslint-disable-next-line no-param-reassign
-        args[existingLoadArgIndex] = `${args[existingLoadArgIndex]},${dirList}`;
+        args.args[existingLoadArgIndex] = `${args.args[existingLoadArgIndex]},${dirList}`;
       } else {
-        args.push(`--load-extension=${dirList}`);
+        args.args.push(`--load-extension=${dirList}`);
       }
     }
     return args;

--- a/templates/background.js
+++ b/templates/background.js
@@ -39,10 +39,10 @@ function executeBrowserCommand(message) {
     if (!method) { // always sync if just accessing property (no method)
       resolve(target);
     } else if (returnType === 'callback') {
-      target[method].apply(this, addPromisifiedCb(args, resolve, reject));
+      target[method].apply(target, addPromisifiedCb(args, resolve, reject));
     } else { // returnType sync or promise
       try {
-        const res = target[message].apply(this, args);
+        const res = target[method].apply(target, args);
         if (res && typeof res.then === 'function') {
           res.then(resolve, reject);
         } else {

--- a/templates/contentscript.js
+++ b/templates/contentscript.js
@@ -4,7 +4,9 @@
 // to the background tab and access the browser/chrome object and the local storage
 // It MAY contain an {{alias}} placeholder, to link it to a specific extension
 // It MAY include JS require statements, as it's then bundled with Browserify
-const log = require('../lib/common').logger({ prefix: 'Cypress ext contentscript' });
+
+const common = require('../lib/common')
+const log = common.logger({ prefix: 'Cypress ext contentscript' });
 
 const targetWindow = window.top;
 
@@ -18,10 +20,25 @@ targetWindow.addEventListener('message', function relayCommandsToBackground(even
   ) {
     const { debug, property, method, cypressExtType } = event.data;
     if (debug) log(`Relaying ${cypressExtType} to backend: ${property}${logMethod(method)}`, event.data);
-    chrome.runtime.sendMessage(event.data, (rawResponse) => {
-      if (typeof rawResponse === 'undefined') return; // sync calls, should we ever add any, don't warrant a callback to Cypress helpers
-      if (debug) log(`Relaying ${rawResponse.error ? 'Error' : 'Success'} ${cypressExtType} ${property}${logMethod(method)} response`, rawResponse, 'to', event.data);
-      targetWindow.postMessage(rawResponse, '*');
-    });
+
+    if(cypressExtType === common.constants.commandType) {
+      chrome.runtime.sendMessage(event.data, (rawResponse) => {
+        if (typeof rawResponse === 'undefined') return; // sync calls, should we ever add any, don't warrant a callback to Cypress helpers
+        if (debug) log(`Relaying ${rawResponse.error ? 'Error' : 'Success'} ${cypressExtType} ${property}${logMethod(method)} response`, rawResponse, 'to', event.data);
+        targetWindow.postMessage(rawResponse, '*');
+      });
+    } else if(cypressExtType === common.constants.messageType) {
+      chrome.runtime.sendMessage(event.data.content, (rawResponse) => {
+        if (typeof rawResponse === 'undefined') return; // sync calls, should we ever add any, don't warrant a callback to Cypress helpers
+        if (debug) log(`Relaying ${rawResponse.error ? 'Error' : 'Success'} ${cypressExtType} chrome.runtime.sendMessage response`, rawResponse, 'to', event.data);
+
+        const fullResponse = {
+          cypressExtType: common.constants.responseType,
+          responseId:     event.data.responseId,
+          ...rawResponse
+        }
+        targetWindow.postMessage(fullResponse, '*');
+      })
+    }
   }
 });


### PR DESCRIPTION
For my purposes I needed to use the ```sendMessage``` interface to pass messages directly to my backend. Using the ```cy.execExtensionCommand``` command was not an option, as messages are not delivered to the page that sends the messages.

Usage is pretty self-explanatory:
```
cy.sendExtensionCommand(message).then(response => console.log(response))
```

This PR also fixes what I think are two typos. See https://github.com/ejoubaud/cypress-browser-extension-plugin/commit/4b8073370ace755baba36778c17f8c3170367416