### PR TITLE
(de)serialize error through message passing

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,5 @@
 const nanoid = require('nanoid');
+const { deserializeError } = require('serialize-error');
 
 const common = require('./lib/common');
 
@@ -19,7 +20,7 @@ function listenForResponse(message, timeout) {
         if (message.debug) log(`Got ${message.property}.${message.method}() response`, data, 'in response to:', message);
         targetWindow.removeEventListener('message', windowListener);
         if (data.error) {
-          reject(data.error);
+          reject(deserializeError(data.error));
         } else {
           resolve(data.response);
         }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chokidar": "^2.0.3",
     "fs-extra": "^5.0.0",
     "nanoid": "^1.0.2",
+    "serialize-error": "^7.0.1",
     "unzip-crx": "^0.2.0"
   }
 }

--- a/templates/background.js
+++ b/templates/background.js
@@ -5,6 +5,7 @@
 // It MAY contain an {{alias}} placeholder, to link it to a specific extension
 // It MAY include JS require statements, as it's then bundled with Browserify
 const common = require('../lib/common');
+const { serializeError } = require('serialize-error');
 
 const { responseType, commandType } = common.constants;
 const log = common.logger({ prefix: 'Cypress ext bg' });
@@ -63,7 +64,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const cypressExtType = responseType;
     executeBrowserCommand(message).then(
       response => sendResponse({ responseId, cypressExtType, response }),
-      error => sendResponse({ responseId, cypressExtType, error }),
+      error => sendResponse({ responseId, cypressExtType, error: serializeError(error) }),
     );
     // tells browser API the response to sendResponse will be async
     return true;


### PR DESCRIPTION
#### What? 

When passing `Error` through Message Passing, they become empty objects

#### Why?

Messages are serialized and deserialized, and errors by default serialize to empty objects.

#### Demo

In `background.js`, **error is an error**
![image](https://user-images.githubusercontent.com/697301/88306318-e09d6580-cd0a-11ea-8fc3-a883c02aebfc.png)

In a callback, **error is an empty object**
![image](https://user-images.githubusercontent.com/697301/88306564-2ce8a580-cd0b-11ea-9edc-2a7226022302.png)

From StackOverflow https://stackoverflow.com/a/50738205/1732483
![image](https://user-images.githubusercontent.com/697301/88306677-51448200-cd0b-11ea-8f52-ec7a46bf748e.png)
